### PR TITLE
Experiment in adding support for Early Hints

### DIFF
--- a/packages/remix-express/server.ts
+++ b/packages/remix-express/server.ts
@@ -57,7 +57,8 @@ export function createRequestHandler({
 
       let response = (await handleRequest(
         request,
-        loadContext
+        loadContext,
+        res.writeEarlyHints.bind(res),
       )) as NodeResponse;
 
       await sendRemixResponse(res, response);


### PR DESCRIPTION
Prototyping potential approaches to the discussion in https://github.com/remix-run/remix/discussions/5378 adding support for [103 Early Hints ](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103)

Using this approach, we can make use of the [`writeEarlyHints`](https://nodejs.org/dist/latest-v18.x/docs/api/http2.html#responsewriteearlyhintshints) functionality available in Node >=18.11 and can add support for other adapters.

```
❯ curl -is http://localhost:3000
HTTP/1.1 103 Early Hints
Link: </build/_assets/tailwind-VDK4BCBP.css>; rel=preload, </favicon.png>; rel=preload

HTTP/1.1 200 OK
X-Powered-By: Express
....
```